### PR TITLE
generate locales via google translate api

### DIFF
--- a/i18n/locales/af.json
+++ b/i18n/locales/af.json
@@ -1,0 +1,17 @@
+{
+    "locale": "af",
+    "language": {
+        "component.date.now": "Tans",
+        "section.skills.title": "Tegniese vaardighede",
+        "section.work.title": "Ervaring",
+        "section.volunteer.title": "Vrywilligerswerk",
+        "section.projects.title": "Projekte",
+        "section.education.title": "Onderwys",
+        "section.awards.title": "Toekennings",
+        "section.publications.title": "Publikasies",
+        "section.languages.title": "Tale",
+        "section.interests.title": "Belange",
+        "section.profiles.title": "Profiele",
+        "section.references.title": "Verwysings"
+    }
+}

--- a/i18n/locales/am.json
+++ b/i18n/locales/am.json
@@ -1,0 +1,17 @@
+{
+    "locale": "am",
+    "language": {
+        "component.date.now": "የአሁኑ ጊዜ",
+        "section.skills.title": "የቴክኒክ ችሎታዎች",
+        "section.work.title": "ልምድ",
+        "section.volunteer.title": "በጎ ፈቃደኝነት",
+        "section.projects.title": "ፕሮጀክቶች",
+        "section.education.title": "ትምህርት",
+        "section.awards.title": "ሽልማቶች",
+        "section.publications.title": "ህትመቶች",
+        "section.languages.title": "ቋንቋዎች",
+        "section.interests.title": "ፍላጎቶች",
+        "section.profiles.title": "መገለጫዎች",
+        "section.references.title": "ዋቢዎች"
+    }
+}

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ar",
+    "language": {
+        "component.date.now": "الوقت الحاضر",
+        "section.skills.title": "مهارات تقنية",
+        "section.work.title": "خبرة",
+        "section.volunteer.title": "التطوع",
+        "section.projects.title": "المشاريع",
+        "section.education.title": "تعليم",
+        "section.awards.title": "الجوائز",
+        "section.publications.title": "المنشورات",
+        "section.languages.title": "اللغات",
+        "section.interests.title": "الإهتمامات",
+        "section.profiles.title": "مظهر",
+        "section.references.title": "مراجع"
+    }
+}

--- a/i18n/locales/az.json
+++ b/i18n/locales/az.json
@@ -1,0 +1,17 @@
+{
+    "locale": "az",
+    "language": {
+        "component.date.now": "İndiki zaman",
+        "section.skills.title": "Texniki Bacarıqlar",
+        "section.work.title": "Təcrübə",
+        "section.volunteer.title": "Könüllülük",
+        "section.projects.title": "Layihələr",
+        "section.education.title": "Təhsil",
+        "section.awards.title": "Mükafatlar",
+        "section.publications.title": "Nəşrlər",
+        "section.languages.title": "Dillər",
+        "section.interests.title": "Maraqlar",
+        "section.profiles.title": "Profillər",
+        "section.references.title": "İstinadlar"
+    }
+}

--- a/i18n/locales/be.json
+++ b/i18n/locales/be.json
@@ -1,0 +1,17 @@
+{
+    "locale": "be",
+    "language": {
+        "component.date.now": "Цяперашні час",
+        "section.skills.title": "Тэхнічныя навыкі",
+        "section.work.title": "Вопыт",
+        "section.volunteer.title": "Валанцёрства",
+        "section.projects.title": "Праекты",
+        "section.education.title": "Адукацыя",
+        "section.awards.title": "Узнагароды",
+        "section.publications.title": "Публікацыі",
+        "section.languages.title": "Мовы",
+        "section.interests.title": "Інтарэсы",
+        "section.profiles.title": "Профілі",
+        "section.references.title": "Літаратура"
+    }
+}

--- a/i18n/locales/bg.json
+++ b/i18n/locales/bg.json
@@ -1,0 +1,17 @@
+{
+    "locale": "bg",
+    "language": {
+        "component.date.now": "Сегашно време",
+        "section.skills.title": "Технически умения",
+        "section.work.title": "Опит",
+        "section.volunteer.title": "Доброволчество",
+        "section.projects.title": "Проекти",
+        "section.education.title": "Образование",
+        "section.awards.title": "награди",
+        "section.publications.title": "Публикации",
+        "section.languages.title": "езици",
+        "section.interests.title": "интереси",
+        "section.profiles.title": "Профили",
+        "section.references.title": "Препратки"
+    }
+}

--- a/i18n/locales/bn.json
+++ b/i18n/locales/bn.json
@@ -1,0 +1,17 @@
+{
+    "locale": "bn",
+    "language": {
+        "component.date.now": "বর্তমান সময়",
+        "section.skills.title": "প্রযুক্তিগত দক্ষতা",
+        "section.work.title": "অভিজ্ঞতা",
+        "section.volunteer.title": "স্বেচ্ছাসেবক",
+        "section.projects.title": "প্রকল্প",
+        "section.education.title": "শিক্ষা",
+        "section.awards.title": "পুরস্কার",
+        "section.publications.title": "প্রকাশনা",
+        "section.languages.title": "ভাষা",
+        "section.interests.title": "আগ্রহ",
+        "section.profiles.title": "প্রোফাইল",
+        "section.references.title": "তথ্যসূত্র"
+    }
+}

--- a/i18n/locales/bs.json
+++ b/i18n/locales/bs.json
@@ -1,0 +1,17 @@
+{
+    "locale": "bs",
+    "language": {
+        "component.date.now": "Sadašnjost",
+        "section.skills.title": "Tehničke vještine",
+        "section.work.title": "Iskustvo",
+        "section.volunteer.title": "Volontiranje",
+        "section.projects.title": "Projekti",
+        "section.education.title": "Obrazovanje",
+        "section.awards.title": "Nagrade",
+        "section.publications.title": "Publikacije",
+        "section.languages.title": "Jezici",
+        "section.interests.title": "Interesi",
+        "section.profiles.title": "Profili",
+        "section.references.title": "Reference"
+    }
+}

--- a/i18n/locales/ca.json
+++ b/i18n/locales/ca.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ca",
+    "language": {
+        "component.date.now": "Temps present",
+        "section.skills.title": "Habilitats tècniques",
+        "section.work.title": "Experiència",
+        "section.volunteer.title": "Voluntariat",
+        "section.projects.title": "Projectes",
+        "section.education.title": "Educació",
+        "section.awards.title": "Premis",
+        "section.publications.title": "Publicacions",
+        "section.languages.title": "Idiomes",
+        "section.interests.title": "Interessos",
+        "section.profiles.title": "Perfils",
+        "section.references.title": "Referències"
+    }
+}

--- a/i18n/locales/cs.json
+++ b/i18n/locales/cs.json
@@ -1,0 +1,17 @@
+{
+    "locale": "cs",
+    "language": {
+        "component.date.now": "Přítomnost",
+        "section.skills.title": "Technické dovednosti",
+        "section.work.title": "Zkušenosti",
+        "section.volunteer.title": "Dobrovolnictví",
+        "section.projects.title": "Projekty",
+        "section.education.title": "Vzdělávání",
+        "section.awards.title": "Ocenění",
+        "section.publications.title": "Publikace",
+        "section.languages.title": "Jazyky",
+        "section.interests.title": "Zájmy",
+        "section.profiles.title": "Profily",
+        "section.references.title": "Reference"
+    }
+}

--- a/i18n/locales/cy.json
+++ b/i18n/locales/cy.json
@@ -1,0 +1,17 @@
+{
+    "locale": "cy",
+    "language": {
+        "component.date.now": "Amser Presennol",
+        "section.skills.title": "Sgiliau Technegol",
+        "section.work.title": "Profiad",
+        "section.volunteer.title": "Gwirfoddoli",
+        "section.projects.title": "Prosiectau",
+        "section.education.title": "Addysg",
+        "section.awards.title": "Gwobrau",
+        "section.publications.title": "Cyhoeddiadau",
+        "section.languages.title": "Ieithoedd",
+        "section.interests.title": "Diddordebau",
+        "section.profiles.title": "Proffiliau",
+        "section.references.title": "Cyfeiriadau"
+    }
+}

--- a/i18n/locales/da.json
+++ b/i18n/locales/da.json
@@ -1,0 +1,17 @@
+{
+    "locale": "da",
+    "language": {
+        "component.date.now": "Nutid",
+        "section.skills.title": "Tekniske færdigheder",
+        "section.work.title": "Erfaring",
+        "section.volunteer.title": "Frivilligt arbejde",
+        "section.projects.title": "Projekter",
+        "section.education.title": "Uddannelse",
+        "section.awards.title": "Priser",
+        "section.publications.title": "Publikationer",
+        "section.languages.title": "Sprog",
+        "section.interests.title": "Interesser",
+        "section.profiles.title": "Profiler",
+        "section.references.title": "Referencer"
+    }
+}

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1,0 +1,17 @@
+{
+    "locale": "de",
+    "language": {
+        "component.date.now": "Gegenwart",
+        "section.skills.title": "Technische Fähigkeiten",
+        "section.work.title": "Erfahrung",
+        "section.volunteer.title": "Freiwilligenarbeit",
+        "section.projects.title": "Projekte",
+        "section.education.title": "Bildung",
+        "section.awards.title": "Auszeichnungen",
+        "section.publications.title": "Veröffentlichungen",
+        "section.languages.title": "Sprachen",
+        "section.interests.title": "Interessen",
+        "section.profiles.title": "Profile",
+        "section.references.title": "Verweise"
+    }
+}

--- a/i18n/locales/el.json
+++ b/i18n/locales/el.json
@@ -1,0 +1,17 @@
+{
+    "locale": "el",
+    "language": {
+        "component.date.now": "Αυτη τη ΣΤΙΓΜΗ",
+        "section.skills.title": "Τεχνικές δεξιότητες",
+        "section.work.title": "Εμπειρία",
+        "section.volunteer.title": "Εθελοντισμός",
+        "section.projects.title": "Εργα",
+        "section.education.title": "Εκπαίδευση",
+        "section.awards.title": "Βραβεία",
+        "section.publications.title": "Δημοσιεύσεις",
+        "section.languages.title": "Γλώσσες",
+        "section.interests.title": "Τα ενδιαφέροντα",
+        "section.profiles.title": "Προφίλ",
+        "section.references.title": "βιβλιογραφικές αναφορές"
+    }
+}

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1,0 +1,17 @@
+{
+    "locale": "es",
+    "language": {
+        "component.date.now": "Tiempo presente",
+        "section.skills.title": "Habilidades técnicas",
+        "section.work.title": "Experiencia",
+        "section.volunteer.title": "Trabajar como voluntario",
+        "section.projects.title": "Proyectos",
+        "section.education.title": "Educación",
+        "section.awards.title": "Premios",
+        "section.publications.title": "Publicaciones",
+        "section.languages.title": "Idiomas",
+        "section.interests.title": "Intereses",
+        "section.profiles.title": "Perfiles",
+        "section.references.title": "Referencias"
+    }
+}

--- a/i18n/locales/et.json
+++ b/i18n/locales/et.json
@@ -1,0 +1,17 @@
+{
+    "locale": "et",
+    "language": {
+        "component.date.now": "Praegune aeg",
+        "section.skills.title": "Tehnilised oskused",
+        "section.work.title": "Kogemused",
+        "section.volunteer.title": "Vabatahtlikkus",
+        "section.projects.title": "Projektid",
+        "section.education.title": "Haridus",
+        "section.awards.title": "Auhinnad",
+        "section.publications.title": "Väljaanded",
+        "section.languages.title": "Keeled",
+        "section.interests.title": "Huvid",
+        "section.profiles.title": "Profiilid",
+        "section.references.title": "Viited"
+    }
+}

--- a/i18n/locales/eu.json
+++ b/i18n/locales/eu.json
@@ -1,0 +1,17 @@
+{
+    "locale": "eu",
+    "language": {
+        "component.date.now": "Oraingo Denbora",
+        "section.skills.title": "Trebetasun Teknikoak",
+        "section.work.title": "Esperientzia",
+        "section.volunteer.title": "Boluntariotza",
+        "section.projects.title": "Proiektuak",
+        "section.education.title": "Hezkuntza",
+        "section.awards.title": "Sariak",
+        "section.publications.title": "Argitalpenak",
+        "section.languages.title": "Hizkuntzak",
+        "section.interests.title": "Interesak",
+        "section.profiles.title": "Profilak",
+        "section.references.title": "Erreferentziak"
+    }
+}

--- a/i18n/locales/fa.json
+++ b/i18n/locales/fa.json
@@ -1,0 +1,17 @@
+{
+    "locale": "fa",
+    "language": {
+        "component.date.now": "زمان حال",
+        "section.skills.title": "مهارتهای فنی",
+        "section.work.title": "تجربه",
+        "section.volunteer.title": "داوطلب شدن",
+        "section.projects.title": "پروژه ها",
+        "section.education.title": "تحصیلات",
+        "section.awards.title": "جوایز",
+        "section.publications.title": "انتشارات",
+        "section.languages.title": "زبان ها",
+        "section.interests.title": "منافع",
+        "section.profiles.title": "پروفایل ها",
+        "section.references.title": "منابع"
+    }
+}

--- a/i18n/locales/fi.json
+++ b/i18n/locales/fi.json
@@ -1,0 +1,17 @@
+{
+    "locale": "fi",
+    "language": {
+        "component.date.now": "Nykyhetki",
+        "section.skills.title": "Teknisiä taitoja",
+        "section.work.title": "Kokea",
+        "section.volunteer.title": "Vapaaehtoistyö",
+        "section.projects.title": "Projektit",
+        "section.education.title": "koulutus",
+        "section.awards.title": "Palkinnot",
+        "section.publications.title": "Julkaisut",
+        "section.languages.title": "Kieli (kielet",
+        "section.interests.title": "Kiinnostuksen kohteet",
+        "section.profiles.title": "Profiilit",
+        "section.references.title": "Viitteet"
+    }
+}

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1,0 +1,17 @@
+{
+    "locale": "fr",
+    "language": {
+        "component.date.now": "Temps présent",
+        "section.skills.title": "Compétences techniques",
+        "section.work.title": "Vivre",
+        "section.volunteer.title": "Faire du bénévolat",
+        "section.projects.title": "Projets",
+        "section.education.title": "Éducation",
+        "section.awards.title": "Récompenses",
+        "section.publications.title": "Ouvrages",
+        "section.languages.title": "Langues",
+        "section.interests.title": "Intérêts",
+        "section.profiles.title": "Profils",
+        "section.references.title": "Références"
+    }
+}

--- a/i18n/locales/gl.json
+++ b/i18n/locales/gl.json
@@ -1,0 +1,17 @@
+{
+    "locale": "gl",
+    "language": {
+        "component.date.now": "Tempo presente",
+        "section.skills.title": "Habilidades técnicas",
+        "section.work.title": "Experiencia",
+        "section.volunteer.title": "Voluntariado",
+        "section.projects.title": "Proxectos",
+        "section.education.title": "Educación",
+        "section.awards.title": "Premios",
+        "section.publications.title": "Publicacións",
+        "section.languages.title": "Linguas",
+        "section.interests.title": "Intereses",
+        "section.profiles.title": "Perfís",
+        "section.references.title": "Referencias"
+    }
+}

--- a/i18n/locales/ha.json
+++ b/i18n/locales/ha.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ha",
+    "language": {
+        "component.date.now": "Lokacin Yanzu",
+        "section.skills.title": "Ƙwarewar Fasaha",
+        "section.work.title": "Kwarewa",
+        "section.volunteer.title": "Sa kai",
+        "section.projects.title": "Ayyuka",
+        "section.education.title": "Ilimi",
+        "section.awards.title": "Kyauta",
+        "section.publications.title": "Labarai",
+        "section.languages.title": "Harsuna",
+        "section.interests.title": "Abubuwan sha'awa",
+        "section.profiles.title": "Bayanan martaba",
+        "section.references.title": "Magana"
+    }
+}

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -1,0 +1,17 @@
+{
+    "locale": "he",
+    "language": {
+        "component.date.now": "הווה",
+        "section.skills.title": "כישורים טכניים",
+        "section.work.title": "ניסיון",
+        "section.volunteer.title": "התנדבות",
+        "section.projects.title": "פרויקטים",
+        "section.education.title": "חינוך",
+        "section.awards.title": "פרסים",
+        "section.publications.title": "פרסומים",
+        "section.languages.title": "שפות",
+        "section.interests.title": "תחומי עניין",
+        "section.profiles.title": "פרופילים",
+        "section.references.title": "הפניות"
+    }
+}

--- a/i18n/locales/hi.json
+++ b/i18n/locales/hi.json
@@ -1,0 +1,17 @@
+{
+    "locale": "hi",
+    "language": {
+        "component.date.now": "वर्तमान समय",
+        "section.skills.title": "तकनीकी कौशल",
+        "section.work.title": "अनुभव",
+        "section.volunteer.title": "स्वयं सेवा",
+        "section.projects.title": "परियोजनाओं",
+        "section.education.title": "शिक्षा",
+        "section.awards.title": "पुरस्कार",
+        "section.publications.title": "प्रकाशनों",
+        "section.languages.title": "बोली",
+        "section.interests.title": "रूचियाँ",
+        "section.profiles.title": "प्रोफाइल",
+        "section.references.title": "संदर्भ"
+    }
+}

--- a/i18n/locales/hr.json
+++ b/i18n/locales/hr.json
@@ -1,0 +1,17 @@
+{
+    "locale": "hr",
+    "language": {
+        "component.date.now": "Sadašnjost",
+        "section.skills.title": "Tehničke vještine",
+        "section.work.title": "Iskustvo",
+        "section.volunteer.title": "Volontiranje",
+        "section.projects.title": "Projekti",
+        "section.education.title": "Obrazovanje",
+        "section.awards.title": "Nagrade",
+        "section.publications.title": "Publikacije",
+        "section.languages.title": "Jezici",
+        "section.interests.title": "Interesi",
+        "section.profiles.title": "Profili",
+        "section.references.title": "Reference"
+    }
+}

--- a/i18n/locales/hu.json
+++ b/i18n/locales/hu.json
@@ -1,0 +1,17 @@
+{
+    "locale": "hu",
+    "language": {
+        "component.date.now": "Jelen idő",
+        "section.skills.title": "Technikai készségek",
+        "section.work.title": "Tapasztalat",
+        "section.volunteer.title": "Önkéntesség",
+        "section.projects.title": "Projektek",
+        "section.education.title": "Oktatás",
+        "section.awards.title": "Díjak",
+        "section.publications.title": "Publikációk",
+        "section.languages.title": "Nyelvek",
+        "section.interests.title": "Érdeklődések",
+        "section.profiles.title": "Profilok",
+        "section.references.title": "Hivatkozások"
+    }
+}

--- a/i18n/locales/hy.json
+++ b/i18n/locales/hy.json
@@ -1,0 +1,17 @@
+{
+    "locale": "hy",
+    "language": {
+        "component.date.now": "Ներկա ժամանակ",
+        "section.skills.title": "Տեխնիկական հմտություններ",
+        "section.work.title": "Փորձ",
+        "section.volunteer.title": "Կամավորություն",
+        "section.projects.title": "Նախագծեր",
+        "section.education.title": "Կրթություն",
+        "section.awards.title": "Մրցանակներ",
+        "section.publications.title": "Հրապարակումներ",
+        "section.languages.title": "Լեզուներ",
+        "section.interests.title": "Հետաքրքրություններ",
+        "section.profiles.title": "Պրոֆիլներ",
+        "section.references.title": "Հղումներ"
+    }
+}

--- a/i18n/locales/id.json
+++ b/i18n/locales/id.json
@@ -1,0 +1,17 @@
+{
+    "locale": "id",
+    "language": {
+        "component.date.now": "Saat ini",
+        "section.skills.title": "Keterampilan teknis",
+        "section.work.title": "Pengalaman",
+        "section.volunteer.title": "Sukarelawan",
+        "section.projects.title": "Proyek",
+        "section.education.title": "Pendidikan",
+        "section.awards.title": "Penghargaan",
+        "section.publications.title": "Publikasi",
+        "section.languages.title": "Bahasa",
+        "section.interests.title": "Minat",
+        "section.profiles.title": "Profil",
+        "section.references.title": "Referensi"
+    }
+}

--- a/i18n/locales/is.json
+++ b/i18n/locales/is.json
@@ -1,0 +1,17 @@
+{
+    "locale": "is",
+    "language": {
+        "component.date.now": "Nútíminn",
+        "section.skills.title": "Tæknilegir hæfileikar",
+        "section.work.title": "Reynsla",
+        "section.volunteer.title": "Sjálfboðaliðastarf",
+        "section.projects.title": "Verkefni",
+        "section.education.title": "Menntun",
+        "section.awards.title": "Verðlaun",
+        "section.publications.title": "Rit",
+        "section.languages.title": "Tungumál",
+        "section.interests.title": "Áhugamál",
+        "section.profiles.title": "Snið",
+        "section.references.title": "Heimildir"
+    }
+}

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1,0 +1,17 @@
+{
+    "locale": "it",
+    "language": {
+        "component.date.now": "Tempo presente",
+        "section.skills.title": "Abilità tecniche",
+        "section.work.title": "Esperienza",
+        "section.volunteer.title": "Volontariato",
+        "section.projects.title": "Progetti",
+        "section.education.title": "Formazione scolastica",
+        "section.awards.title": "Premi",
+        "section.publications.title": "Pubblicazioni",
+        "section.languages.title": "Le lingue",
+        "section.interests.title": "Interessi",
+        "section.profiles.title": "Profili",
+        "section.references.title": "Riferimenti"
+    }
+}

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ja",
+    "language": {
+        "component.date.now": "現時点",
+        "section.skills.title": "技術的なスキル",
+        "section.work.title": "経験",
+        "section.volunteer.title": "ボランティア",
+        "section.projects.title": "プロジェクト",
+        "section.education.title": "教育",
+        "section.awards.title": "賞",
+        "section.publications.title": "出版物",
+        "section.languages.title": "言語",
+        "section.interests.title": "興味",
+        "section.profiles.title": "プロファイル",
+        "section.references.title": "参考文献"
+    }
+}

--- a/i18n/locales/ka.json
+++ b/i18n/locales/ka.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ka",
+    "language": {
+        "component.date.now": "Აწმყო დრო",
+        "section.skills.title": "ტექნიკური უნარები",
+        "section.work.title": "გამოცდილება",
+        "section.volunteer.title": "Მოხალისეობა",
+        "section.projects.title": "პროექტები",
+        "section.education.title": "Განათლება",
+        "section.awards.title": "Ჯილდო",
+        "section.publications.title": "პუბლიკაციები",
+        "section.languages.title": "ენები",
+        "section.interests.title": "ინტერესები",
+        "section.profiles.title": "პროფილები",
+        "section.references.title": "ცნობები"
+    }
+}

--- a/i18n/locales/kk.json
+++ b/i18n/locales/kk.json
@@ -1,0 +1,17 @@
+{
+    "locale": "kk",
+    "language": {
+        "component.date.now": "Қазіргі уақыт",
+        "section.skills.title": "Техникалық дағдылар",
+        "section.work.title": "Тәжірибе",
+        "section.volunteer.title": "Волонтерлік",
+        "section.projects.title": "Жобалар",
+        "section.education.title": "Білім",
+        "section.awards.title": "Марапаттары",
+        "section.publications.title": "Жарияланымдар",
+        "section.languages.title": "Тілдер",
+        "section.interests.title": "Қызығушылықтар",
+        "section.profiles.title": "Профильдер",
+        "section.references.title": "Анықтамалар"
+    }
+}

--- a/i18n/locales/km.json
+++ b/i18n/locales/km.json
@@ -1,0 +1,17 @@
+{
+    "locale": "km",
+    "language": {
+        "component.date.now": "ពេលបច្ចុប្បន្ន",
+        "section.skills.title": "ជំនាញបច្ចេកទេស",
+        "section.work.title": "បទពិសោធន៍",
+        "section.volunteer.title": "ការងារស្ម័គ្រចិត្ត",
+        "section.projects.title": "គម្រោង",
+        "section.education.title": "ការអប់រំ",
+        "section.awards.title": "រង្វាន់",
+        "section.publications.title": "ការបោះពុម្ពផ្សាយ",
+        "section.languages.title": "ភាសា",
+        "section.interests.title": "ចំណាប់អារម្មណ៍",
+        "section.profiles.title": "ប្រវត្តិរូប",
+        "section.references.title": "ឯកសារយោង"
+    }
+}

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ko",
+    "language": {
+        "component.date.now": "현재 시간",
+        "section.skills.title": "기술 능력",
+        "section.work.title": "경험",
+        "section.volunteer.title": "자원",
+        "section.projects.title": "프로젝트",
+        "section.education.title": "교육",
+        "section.awards.title": "수상",
+        "section.publications.title": "간행물",
+        "section.languages.title": "언어",
+        "section.interests.title": "이해",
+        "section.profiles.title": "프로필",
+        "section.references.title": "참고문헌"
+    }
+}

--- a/i18n/locales/ku.json
+++ b/i18n/locales/ku.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ku",
+    "language": {
+        "component.date.now": "Dema niha",
+        "section.skills.title": "Technical Skills",
+        "section.work.title": "Tecribe",
+        "section.volunteer.title": "Dilxwazî",
+        "section.projects.title": "Projects",
+        "section.education.title": "Zanyarî",
+        "section.awards.title": "Xelat",
+        "section.publications.title": "Weşanên",
+        "section.languages.title": "Languages",
+        "section.interests.title": "Interests",
+        "section.profiles.title": "Profiles",
+        "section.references.title": "Çavkanî"
+    }
+}

--- a/i18n/locales/ky.json
+++ b/i18n/locales/ky.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ky",
+    "language": {
+        "component.date.now": "Учур чак",
+        "section.skills.title": "Техникалык көндүмдөр",
+        "section.work.title": "Тажрыйба",
+        "section.volunteer.title": "Волонтерлук",
+        "section.projects.title": "Долбоорлор",
+        "section.education.title": "Билим берүү",
+        "section.awards.title": "Сыйлыктар",
+        "section.publications.title": "Басылмалар",
+        "section.languages.title": "Тилдер",
+        "section.interests.title": "Кызыкчылыктар",
+        "section.profiles.title": "Профильдер",
+        "section.references.title": "Шилтемелер"
+    }
+}

--- a/i18n/locales/lt.json
+++ b/i18n/locales/lt.json
@@ -1,0 +1,17 @@
+{
+    "locale": "lt",
+    "language": {
+        "component.date.now": "Esamasis laikas",
+        "section.skills.title": "Techniniai įgūdžiai",
+        "section.work.title": "Patirtis",
+        "section.volunteer.title": "Savanoriška veikla",
+        "section.projects.title": "Projektai",
+        "section.education.title": "Išsilavinimas",
+        "section.awards.title": "Apdovanojimai",
+        "section.publications.title": "Publikacijos",
+        "section.languages.title": "Kalbos",
+        "section.interests.title": "Pomėgiai",
+        "section.profiles.title": "Profiliai",
+        "section.references.title": "Nuorodos"
+    }
+}

--- a/i18n/locales/lv.json
+++ b/i18n/locales/lv.json
@@ -1,0 +1,17 @@
+{
+    "locale": "lv",
+    "language": {
+        "component.date.now": "Pašreizējais laiks",
+        "section.skills.title": "Tehniskās iemaņas",
+        "section.work.title": "Pieredze",
+        "section.volunteer.title": "Brīvprātīgais darbs",
+        "section.projects.title": "Projekti",
+        "section.education.title": "Izglītība",
+        "section.awards.title": "Apbalvojumi",
+        "section.publications.title": "Publikācijas",
+        "section.languages.title": "Valodas",
+        "section.interests.title": "Intereses",
+        "section.profiles.title": "Profili",
+        "section.references.title": "Atsauces"
+    }
+}

--- a/i18n/locales/mk.json
+++ b/i18n/locales/mk.json
@@ -1,0 +1,17 @@
+{
+    "locale": "mk",
+    "language": {
+        "component.date.now": "Сегашно време",
+        "section.skills.title": "Технички вештини",
+        "section.work.title": "Искуство",
+        "section.volunteer.title": "Волонтирање",
+        "section.projects.title": "Проекти",
+        "section.education.title": "Образование",
+        "section.awards.title": "Награди",
+        "section.publications.title": "Публикации",
+        "section.languages.title": "Јазици",
+        "section.interests.title": "Интереси",
+        "section.profiles.title": "Профили",
+        "section.references.title": "Референци"
+    }
+}

--- a/i18n/locales/ml.json
+++ b/i18n/locales/ml.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ml",
+    "language": {
+        "component.date.now": "ഇപ്പോൾ",
+        "section.skills.title": "സാങ്കേതിക കഴിവുകളും",
+        "section.work.title": "അനുഭവം",
+        "section.volunteer.title": "സന്നദ്ധസേവനം",
+        "section.projects.title": "പദ്ധതികൾ",
+        "section.education.title": "വിദ്യാഭ്യാസം",
+        "section.awards.title": "അവാർഡുകൾ",
+        "section.publications.title": "പ്രസിദ്ധീകരണങ്ങൾ",
+        "section.languages.title": "ഭാഷകൾ",
+        "section.interests.title": "താൽപ്പര്യങ്ങൾ",
+        "section.profiles.title": "പ്രൊഫൈലുകൾ",
+        "section.references.title": "റഫറൻസുകൾ"
+    }
+}

--- a/i18n/locales/mn.json
+++ b/i18n/locales/mn.json
@@ -1,0 +1,17 @@
+{
+    "locale": "mn",
+    "language": {
+        "component.date.now": "Одоо цаг",
+        "section.skills.title": "Техникийн ур чадвар",
+        "section.work.title": "Туршлага",
+        "section.volunteer.title": "Сайн дурын ажил",
+        "section.projects.title": "Төслүүд",
+        "section.education.title": "Боловсрол",
+        "section.awards.title": "Шагнал",
+        "section.publications.title": "Хэвлэлүүд",
+        "section.languages.title": "Хэлнүүд",
+        "section.interests.title": "Сонирхол",
+        "section.profiles.title": "Профайлууд",
+        "section.references.title": "Лавлагаа"
+    }
+}

--- a/i18n/locales/ms.json
+++ b/i18n/locales/ms.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ms",
+    "language": {
+        "component.date.now": "Masa kini",
+        "section.skills.title": "Kemahiran teknikal",
+        "section.work.title": "Pengalaman",
+        "section.volunteer.title": "Sukarelawan",
+        "section.projects.title": "Projek",
+        "section.education.title": "Pendidikan",
+        "section.awards.title": "Anugerah",
+        "section.publications.title": "Penerbitan",
+        "section.languages.title": "Bahasa",
+        "section.interests.title": "minat",
+        "section.profiles.title": "Profil",
+        "section.references.title": "Rujukan"
+    }
+}

--- a/i18n/locales/nb.json
+++ b/i18n/locales/nb.json
@@ -1,0 +1,17 @@
+{
+    "locale": "nb",
+    "language": {
+        "component.date.now": "Nåtid",
+        "section.skills.title": "Tekniske ferdigheter",
+        "section.work.title": "Erfaring",
+        "section.volunteer.title": "Frivillig arbeid",
+        "section.projects.title": "Prosjekter",
+        "section.education.title": "utdanning",
+        "section.awards.title": "Priser",
+        "section.publications.title": "Publikasjoner",
+        "section.languages.title": "Språk",
+        "section.interests.title": "Interesser",
+        "section.profiles.title": "Profiler",
+        "section.references.title": "Referanser"
+    }
+}

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -1,0 +1,17 @@
+{
+    "locale": "nl",
+    "language": {
+        "component.date.now": "Tegenwoordige tijd",
+        "section.skills.title": "Technische vaardigheden",
+        "section.work.title": "Beleven",
+        "section.volunteer.title": "Vrijwilligerswerk",
+        "section.projects.title": "projecten",
+        "section.education.title": "Opleiding",
+        "section.awards.title": "onderscheidingen",
+        "section.publications.title": "publicaties",
+        "section.languages.title": "Talen",
+        "section.interests.title": "interesses",
+        "section.profiles.title": "Profielen",
+        "section.references.title": "Referenties"
+    }
+}

--- a/i18n/locales/nn.json
+++ b/i18n/locales/nn.json
@@ -1,0 +1,17 @@
+{
+    "locale": "nn",
+    "language": {
+        "component.date.now": "Nåtid",
+        "section.skills.title": "Tekniske ferdigheter",
+        "section.work.title": "Erfaring",
+        "section.volunteer.title": "Frivillig arbeid",
+        "section.projects.title": "Prosjekter",
+        "section.education.title": "utdanning",
+        "section.awards.title": "Priser",
+        "section.publications.title": "Publikasjoner",
+        "section.languages.title": "Språk",
+        "section.interests.title": "Interesser",
+        "section.profiles.title": "Profiler",
+        "section.references.title": "Referanser"
+    }
+}

--- a/i18n/locales/no.json
+++ b/i18n/locales/no.json
@@ -1,0 +1,17 @@
+{
+    "locale": "no",
+    "language": {
+        "component.date.now": "Nåtid",
+        "section.skills.title": "Tekniske ferdigheter",
+        "section.work.title": "Erfaring",
+        "section.volunteer.title": "Frivillig arbeid",
+        "section.projects.title": "Prosjekter",
+        "section.education.title": "utdanning",
+        "section.awards.title": "Priser",
+        "section.publications.title": "Publikasjoner",
+        "section.languages.title": "Språk",
+        "section.interests.title": "Interesser",
+        "section.profiles.title": "Profiler",
+        "section.references.title": "Referanser"
+    }
+}

--- a/i18n/locales/pl.json
+++ b/i18n/locales/pl.json
@@ -1,0 +1,17 @@
+{
+    "locale": "pl",
+    "language": {
+        "component.date.now": "Czas teraźniejszy",
+        "section.skills.title": "Umiejętności techniczne",
+        "section.work.title": "Doświadczenie",
+        "section.volunteer.title": "Zgłaszanie się na ochotnika",
+        "section.projects.title": "Projektowanie",
+        "section.education.title": "Edukacja",
+        "section.awards.title": "Nagrody",
+        "section.publications.title": "Publikacje",
+        "section.languages.title": "Języki",
+        "section.interests.title": "Zainteresowania",
+        "section.profiles.title": "Profile",
+        "section.references.title": "Bibliografia"
+    }
+}

--- a/i18n/locales/ps.json
+++ b/i18n/locales/ps.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ps",
+    "language": {
+        "component.date.now": "اوسنی وخت",
+        "section.skills.title": "تخنيکي مهارتونه",
+        "section.work.title": "تجربه",
+        "section.volunteer.title": "رضاکارانه کار کول",
+        "section.projects.title": "پروژې",
+        "section.education.title": "زده کړه",
+        "section.awards.title": "جایزې",
+        "section.publications.title": "خپرونې",
+        "section.languages.title": "ژبې",
+        "section.interests.title": "ګټو",
+        "section.profiles.title": "پروفایلونه",
+        "section.references.title": "حوالې"
+    }
+}

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -1,0 +1,17 @@
+{
+    "locale": "pt",
+    "language": {
+        "component.date.now": "Tempo presente",
+        "section.skills.title": "Habilidades técnicas",
+        "section.work.title": "Experiência",
+        "section.volunteer.title": "Voluntariado",
+        "section.projects.title": "Projetos",
+        "section.education.title": "Educação",
+        "section.awards.title": "Prêmios",
+        "section.publications.title": "Publicações",
+        "section.languages.title": "línguas",
+        "section.interests.title": "Interesses",
+        "section.profiles.title": "Perfis",
+        "section.references.title": "Referências"
+    }
+}

--- a/i18n/locales/ro.json
+++ b/i18n/locales/ro.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ro",
+    "language": {
+        "component.date.now": "Timp prezent",
+        "section.skills.title": "Abilitati tehnice",
+        "section.work.title": "Experienţă",
+        "section.volunteer.title": "Voluntariat",
+        "section.projects.title": "Proiecte",
+        "section.education.title": "Educaţie",
+        "section.awards.title": "Premii",
+        "section.publications.title": "Publicaţii",
+        "section.languages.title": "Limbi",
+        "section.interests.title": "Interese",
+        "section.profiles.title": "Profiluri",
+        "section.references.title": "Referințe"
+    }
+}

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ru",
+    "language": {
+        "component.date.now": "Настоящее время",
+        "section.skills.title": "Технические навыки",
+        "section.work.title": "Опыт",
+        "section.volunteer.title": "Волонтерство",
+        "section.projects.title": "Проекты",
+        "section.education.title": "Образование",
+        "section.awards.title": "Награды",
+        "section.publications.title": "Публикации",
+        "section.languages.title": "Языки",
+        "section.interests.title": "Интересы",
+        "section.profiles.title": "Профили",
+        "section.references.title": "Рекомендации"
+    }
+}

--- a/i18n/locales/sd.json
+++ b/i18n/locales/sd.json
@@ -1,0 +1,17 @@
+{
+    "locale": "sd",
+    "language": {
+        "component.date.now": "موجوده وقت",
+        "section.skills.title": "ٽيڪنيڪل صلاحيتن",
+        "section.work.title": "تجربو",
+        "section.volunteer.title": "رضاڪارانه",
+        "section.projects.title": "منصوبا",
+        "section.education.title": "تعليم",
+        "section.awards.title": "انعام",
+        "section.publications.title": "پبليڪيشن",
+        "section.languages.title": "ٻوليون",
+        "section.interests.title": "دلچسپيون",
+        "section.profiles.title": "پروفائلز",
+        "section.references.title": "حوالا"
+    }
+}

--- a/i18n/locales/sk.json
+++ b/i18n/locales/sk.json
@@ -1,0 +1,17 @@
+{
+    "locale": "sk",
+    "language": {
+        "component.date.now": "Súčasnosť",
+        "section.skills.title": "Technické zručnosti",
+        "section.work.title": "Skúsenosti",
+        "section.volunteer.title": "Dobrovoľníctvo",
+        "section.projects.title": "projekty",
+        "section.education.title": "Vzdelávanie",
+        "section.awards.title": "ocenenia",
+        "section.publications.title": "Publikácie",
+        "section.languages.title": "Jazyky",
+        "section.interests.title": "Záujmy",
+        "section.profiles.title": "Profily",
+        "section.references.title": "Referencie"
+    }
+}

--- a/i18n/locales/sl.json
+++ b/i18n/locales/sl.json
@@ -1,0 +1,17 @@
+{
+    "locale": "sl",
+    "language": {
+        "component.date.now": "Sedanjik",
+        "section.skills.title": "Tehnična znanja",
+        "section.work.title": "Izkušnje",
+        "section.volunteer.title": "Prostovoljstvo",
+        "section.projects.title": "Projekti",
+        "section.education.title": "Izobraževanje",
+        "section.awards.title": "Nagrade",
+        "section.publications.title": "Publikacije",
+        "section.languages.title": "jeziki",
+        "section.interests.title": "Zanimanja",
+        "section.profiles.title": "Profili",
+        "section.references.title": "Reference"
+    }
+}

--- a/i18n/locales/so.json
+++ b/i18n/locales/so.json
@@ -1,0 +1,17 @@
+{
+    "locale": "so",
+    "language": {
+        "component.date.now": "Waqtiga xaadirka ah",
+        "section.skills.title": "Xirfadaha Farsamada",
+        "section.work.title": "Khibrad",
+        "section.volunteer.title": "Iskaa wax u qabso",
+        "section.projects.title": "Mashaariicda",
+        "section.education.title": "Waxbarasho",
+        "section.awards.title": "Abaalmarino",
+        "section.publications.title": "Daabacaad",
+        "section.languages.title": "Luuqadaha",
+        "section.interests.title": "Danaha",
+        "section.profiles.title": "Profiles",
+        "section.references.title": "Tixraacyo"
+    }
+}

--- a/i18n/locales/sq.json
+++ b/i18n/locales/sq.json
@@ -1,0 +1,17 @@
+{
+    "locale": "sq",
+    "language": {
+        "component.date.now": "Koha e tashme",
+        "section.skills.title": "Aftësitë teknike",
+        "section.work.title": "Përvoja",
+        "section.volunteer.title": "Vullnetarizmi",
+        "section.projects.title": "Projektet",
+        "section.education.title": "Arsimi",
+        "section.awards.title": "Çmimet",
+        "section.publications.title": "Publikimet",
+        "section.languages.title": "Gjuhët",
+        "section.interests.title": "Interesat",
+        "section.profiles.title": "Profilet",
+        "section.references.title": "Referencat"
+    }
+}

--- a/i18n/locales/sr.json
+++ b/i18n/locales/sr.json
@@ -1,0 +1,17 @@
+{
+    "locale": "sr",
+    "language": {
+        "component.date.now": "Садашњост",
+        "section.skills.title": "Техничке вештине",
+        "section.work.title": "Искуство",
+        "section.volunteer.title": "Волонтирање",
+        "section.projects.title": "Пројекти",
+        "section.education.title": "образовање",
+        "section.awards.title": "Награде",
+        "section.publications.title": "Публикације",
+        "section.languages.title": "Језици",
+        "section.interests.title": "Интереси",
+        "section.profiles.title": "Профили",
+        "section.references.title": "Референце"
+    }
+}

--- a/i18n/locales/sv.json
+++ b/i18n/locales/sv.json
@@ -1,0 +1,17 @@
+{
+    "locale": "sv",
+    "language": {
+        "component.date.now": "Nutid",
+        "section.skills.title": "Tekniska förmågor",
+        "section.work.title": "Erfarenhet",
+        "section.volunteer.title": "Volontärarbete",
+        "section.projects.title": "Projekt",
+        "section.education.title": "Utbildning",
+        "section.awards.title": "Utmärkelser",
+        "section.publications.title": "Publikationer",
+        "section.languages.title": "språk",
+        "section.interests.title": "Intressen",
+        "section.profiles.title": "Profiler",
+        "section.references.title": "Referenser"
+    }
+}

--- a/i18n/locales/sw.json
+++ b/i18n/locales/sw.json
@@ -1,0 +1,17 @@
+{
+    "locale": "sw",
+    "language": {
+        "component.date.now": "Wakati uliopo",
+        "section.skills.title": "Ujuzi wa Kiufundi",
+        "section.work.title": "Uzoefu",
+        "section.volunteer.title": "Kujitolea",
+        "section.projects.title": "Miradi",
+        "section.education.title": "Elimu",
+        "section.awards.title": "Tuzo",
+        "section.publications.title": "Machapisho",
+        "section.languages.title": "Lugha",
+        "section.interests.title": "Maslahi",
+        "section.profiles.title": "Wasifu",
+        "section.references.title": "Marejeleo"
+    }
+}

--- a/i18n/locales/ta.json
+++ b/i18n/locales/ta.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ta",
+    "language": {
+        "component.date.now": "தற்போதைய நேரம்",
+        "section.skills.title": "தொழில்நுட்ப திறன்கள்",
+        "section.work.title": "அனுபவம்",
+        "section.volunteer.title": "தன்னார்வத் தொண்டு",
+        "section.projects.title": "திட்டங்கள்",
+        "section.education.title": "கல்வி",
+        "section.awards.title": "விருதுகள்",
+        "section.publications.title": "வெளியீடுகள்",
+        "section.languages.title": "மொழிகள்",
+        "section.interests.title": "ஆர்வங்கள்",
+        "section.profiles.title": "சுயவிவரங்கள்",
+        "section.references.title": "குறிப்புகள்"
+    }
+}

--- a/i18n/locales/tg.json
+++ b/i18n/locales/tg.json
@@ -1,0 +1,17 @@
+{
+    "locale": "tg",
+    "language": {
+        "component.date.now": "Замони ҳозира",
+        "section.skills.title": "Малакаҳои техникӣ",
+        "section.work.title": "Таҷриба",
+        "section.volunteer.title": "Волонтёрӣ",
+        "section.projects.title": "Лоиҳаҳо",
+        "section.education.title": "Маориф",
+        "section.awards.title": "Мукофотхо",
+        "section.publications.title": "Нашрияҳо",
+        "section.languages.title": "Забонҳо",
+        "section.interests.title": "Манфиатҳо",
+        "section.profiles.title": "Профилҳо",
+        "section.references.title": "Иқтибосҳо"
+    }
+}

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -1,0 +1,17 @@
+{
+    "locale": "th",
+    "language": {
+        "component.date.now": "เวลาปัจจุบัน",
+        "section.skills.title": "ทักษะทางเทคนิค",
+        "section.work.title": "ประสบการณ์",
+        "section.volunteer.title": "อาสาสมัคร",
+        "section.projects.title": "โครงการ",
+        "section.education.title": "การศึกษา",
+        "section.awards.title": "รางวัล",
+        "section.publications.title": "สิ่งพิมพ์",
+        "section.languages.title": "ภาษา",
+        "section.interests.title": "ความสนใจ",
+        "section.profiles.title": "โปรไฟล์",
+        "section.references.title": "อ้างอิง"
+    }
+}

--- a/i18n/locales/tr.json
+++ b/i18n/locales/tr.json
@@ -1,0 +1,17 @@
+{
+    "locale": "tr",
+    "language": {
+        "component.date.now": "Şimdiki zaman",
+        "section.skills.title": "Teknik beceriler",
+        "section.work.title": "Tecrübe etmek",
+        "section.volunteer.title": "gönüllülük",
+        "section.projects.title": "Projeler",
+        "section.education.title": "Eğitim",
+        "section.awards.title": "Ödüller",
+        "section.publications.title": "Yayınlar",
+        "section.languages.title": "Diller",
+        "section.interests.title": "ilgi alanları",
+        "section.profiles.title": "profiller",
+        "section.references.title": "Referanslar"
+    }
+}

--- a/i18n/locales/tt.json
+++ b/i18n/locales/tt.json
@@ -1,0 +1,17 @@
+{
+    "locale": "tt",
+    "language": {
+        "component.date.now": "Хәзерге вакыт",
+        "section.skills.title": "Техник осталык",
+        "section.work.title": "Тәҗрибә",
+        "section.volunteer.title": "Волонтерлык",
+        "section.projects.title": "Проектлар",
+        "section.education.title": "Мәгариф",
+        "section.awards.title": "Бүләкләр",
+        "section.publications.title": "Басмалар",
+        "section.languages.title": "Телләр",
+        "section.interests.title": "Кызыксынулар",
+        "section.profiles.title": "Профильләр",
+        "section.references.title": "Белешмәләр"
+    }
+}

--- a/i18n/locales/ug.json
+++ b/i18n/locales/ug.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ug",
+    "language": {
+        "component.date.now": "ھازىرقى ۋاقىت",
+        "section.skills.title": "تېخنىكىلىق ماھارەت",
+        "section.work.title": "تەجرىبە",
+        "section.volunteer.title": "پىدائىيلار",
+        "section.projects.title": "Projects",
+        "section.education.title": "مائارىپ",
+        "section.awards.title": "مۇكاپات",
+        "section.publications.title": "نەشر بۇيۇملىرى",
+        "section.languages.title": "تىللار",
+        "section.interests.title": "قىزىقىش",
+        "section.profiles.title": "Profiles",
+        "section.references.title": "پايدىلانما"
+    }
+}

--- a/i18n/locales/uk.json
+++ b/i18n/locales/uk.json
@@ -1,0 +1,17 @@
+{
+    "locale": "uk",
+    "language": {
+        "component.date.now": "Теперішній час",
+        "section.skills.title": "Технічні навички",
+        "section.work.title": "Досвід",
+        "section.volunteer.title": "Волонтерство",
+        "section.projects.title": "Проекти",
+        "section.education.title": "Освіта",
+        "section.awards.title": "Нагороди",
+        "section.publications.title": "Публікації",
+        "section.languages.title": "Мови",
+        "section.interests.title": "Інтереси",
+        "section.profiles.title": "Профілі",
+        "section.references.title": "Посилання"
+    }
+}

--- a/i18n/locales/ur.json
+++ b/i18n/locales/ur.json
@@ -1,0 +1,17 @@
+{
+    "locale": "ur",
+    "language": {
+        "component.date.now": "موجودہ وقت",
+        "section.skills.title": "تکنیکی مہارت",
+        "section.work.title": "تجربہ",
+        "section.volunteer.title": "رضاکارانہ",
+        "section.projects.title": "پروجیکٹس",
+        "section.education.title": "تعلیم",
+        "section.awards.title": "ایوارڈز",
+        "section.publications.title": "اشاعتیں",
+        "section.languages.title": "زبانیں",
+        "section.interests.title": "دلچسپیاں",
+        "section.profiles.title": "پروفائلز",
+        "section.references.title": "حوالہ جات"
+    }
+}

--- a/i18n/locales/uz.json
+++ b/i18n/locales/uz.json
@@ -1,0 +1,17 @@
+{
+    "locale": "uz",
+    "language": {
+        "component.date.now": "Hozirgi vaqt",
+        "section.skills.title": "Texnik ko'nikmalar",
+        "section.work.title": "Tajriba",
+        "section.volunteer.title": "Ko'ngillilik",
+        "section.projects.title": "Loyihalar",
+        "section.education.title": "Ta'lim",
+        "section.awards.title": "Mukofotlar",
+        "section.publications.title": "Nashrlar",
+        "section.languages.title": "Tillar",
+        "section.interests.title": "Qiziqishlar",
+        "section.profiles.title": "Profillar",
+        "section.references.title": "Ma'lumotnomalar"
+    }
+}

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -1,0 +1,17 @@
+{
+    "locale": "vi",
+    "language": {
+        "component.date.now": "Hiện nay",
+        "section.skills.title": "Kĩ năng công nghệ",
+        "section.work.title": "Trải qua",
+        "section.volunteer.title": "Tình nguyện",
+        "section.projects.title": "Dự án",
+        "section.education.title": "Giáo dục",
+        "section.awards.title": "Giải thưởng",
+        "section.publications.title": "Ấn phẩm",
+        "section.languages.title": "Ngôn ngữ",
+        "section.interests.title": "Sở thích",
+        "section.profiles.title": "Hồ sơ",
+        "section.references.title": "Người giới thiệu"
+    }
+}

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -1,0 +1,17 @@
+{
+    "locale": "zh",
+    "language": {
+        "component.date.now": "现在时间",
+        "section.skills.title": "技术能力",
+        "section.work.title": "经验",
+        "section.volunteer.title": "志愿服务",
+        "section.projects.title": "项目",
+        "section.education.title": "教育",
+        "section.awards.title": "奖项",
+        "section.publications.title": "出版物",
+        "section.languages.title": "语言",
+        "section.interests.title": "兴趣",
+        "section.profiles.title": "简介",
+        "section.references.title": "参考"
+    }
+}


### PR DESCRIPTION
I speak two languages, English & JavaScript... there are no doubt inaccuracies in these translations as there's no context associated with the wording, however this _should_ be a reasonable first pass - folks are welcome to suggest changes as necessary. I didn't want to commit this script to the repo but I'll leave it on the PR for reference. 

```js
/** 
 * ./locales/translate.mjs
 * 
 * translate() { TARGET=$1 node i18n/translate.mjs ; }
 * translate <target>
 */ 

import path from 'path'
import { fileURLToPath } from 'url'
import { promises as fs } from 'fs'
import { createRequire } from 'module'
import { v2 } from '@google-cloud/translate'

const __dirname = path.dirname(fileURLToPath(import.meta.url))

const TARGET = process.env.TARGET
const LANG_EN = createRequire(import.meta.url)(
    path.join(__dirname, 'locales', 'en.json')
)

const api = new v2.Translate({
    key: '<API_KEY>',
})

if (!TARGET) {
    console.log('[err] no target')
    process.exit(1)
}

;(async function main() {
    async function translate(lang, target) {
        let [translations] = await api.translate(Object.values(lang), target)
        translations = Array.isArray(translations)
            ? translations
            : [translations]

        return Object.keys(lang).reduce(
            (acc, key, i) => {
                acc.language[key] = translations[i]
                return acc
            },
            {
                locale: target,
                language: {},
            }
        )
    }

    const targetTranslation = await translate(LANG_EN.language, TARGET)
    const targetJson = JSON.stringify(targetTranslation, null, 4)
    await fs.writeFile(
        path.join(__dirname, 'locales', `${TARGET}.json`),
        targetJson,
        'utf8'
    )
    console.log(targetJson)

    const reversal = await translate(targetTranslation.language, 'en')
    console.log(JSON.stringify(reversal, null, 4))
})()
```